### PR TITLE
修复 敏感词提示重复 的问题

### DIFF
--- a/src/CheckForSensitiveWords.ts
+++ b/src/CheckForSensitiveWords.ts
@@ -6,7 +6,7 @@ const diagnosticCollection = vscode.languages.createDiagnosticCollection('sensit
 export function checkForSensitiveWords(editor: vscode.TextEditor, mint: Mint) {
   const document = editor.document;
   const text = document.getText();
-  const sensitiveWords = mint.filter(text).words;
+  const sensitiveWords = new Set(mint.filter(text).words); // fix: https://github.com/qxchuckle/vsc-cec-ide/issues/25 把敏感词的列表转成 Set 来去重，防止每个词被提示多次
   const diagnostics: vscode.Diagnostic[] = [];
   
   // 使用正则表达式来匹配所有敏感词的出现位置


### PR DESCRIPTION
如 #25 所示，当文中出现多个重复的敏感词时会有重复提示，这里修复了这个问题

![image](https://github.com/qxchuckle/vsc-cec-ide/assets/94808542/098a0508-7854-4269-a9f2-3e26bdb4c3f3)

如图所示，代码正常工作了