### PR TITLE
修复敏感词重叠时导致的无法一键修复问题

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,9 +35,7 @@ English document at the end of the text
 
 ![image](https://github.com/qxchuckle/vsc-cec-ide/assets/55614189/49e49ff2-8db6-4dac-ba3b-94899db3e226)
 
-0.1.3 版本后新增了快速修复功能，一键替换为***
-
-![image](https://github.com/qxchuckle/vsc-cec-ide/assets/55614189/091a63f6-b16d-4b5e-93ad-403807582d25)
+0.1.3 版本后新增了快速修复功能，一键替换该敏感词或所有敏感词为***
 
 点击右下角状态栏按钮，也能开始检测或停止检测，且在检测中会显示当前活动编辑器含有的敏感词数。
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cec-ide",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "cec-ide",
-      "version": "0.1.4",
+      "version": "0.1.5",
       "dependencies": {
         "mint-filter": "^4.0.3"
       },

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "type": "git",
     "url": "https://github.com/qxchuckle/vsc-cec-ide.git"
   },
-  "version": "0.1.4",
+  "version": "0.1.5",
   "engines": {
     "vscode": "^1.70.0"
   },

--- a/src/sensitiveWords/CodeActionProvider.ts
+++ b/src/sensitiveWords/CodeActionProvider.ts
@@ -12,22 +12,52 @@ export function createCodeActionProvider(diagnosticSource: string, diagnosticCol
       for (const diagnostic of context.diagnostics) {
         // 仅处理指定的诊断来源
         if (diagnostic.source === diagnosticSource) {
-          const fix = new vscode.CodeAction('将敏感词替换为***', vscode.CodeActionKind.QuickFix);
+          const fix = new vscode.CodeAction(`将敏感词 ${document.getText(diagnostic.range)} 替换为***`, vscode.CodeActionKind.QuickFix);
           fix.edit = new vscode.WorkspaceEdit();
           fix.edit.replace(document.uri, diagnostic.range, '*'.repeat(diagnostic.range.end.character - diagnostic.range.start.character));
           fix.diagnostics = [diagnostic];
           actions.push(fix);
-          const diagnosticsOnCurrentDocument = diagnosticCollection.get(document.uri);
-          if (diagnosticsOnCurrentDocument) {
-            const fixAll = new vscode.CodeAction('一键修复所有敏感词', vscode.CodeActionKind.QuickFix);
-            fixAll.edit = new vscode.WorkspaceEdit();
-            diagnosticsOnCurrentDocument.forEach(diagnostic => {
-              fixAll.edit!.replace(document.uri, diagnostic.range, '*'.repeat(diagnostic.range.end.character - diagnostic.range.start.character));
-            });
-            fixAll.diagnostics = [...diagnosticsOnCurrentDocument];
-            actions.push(fixAll);
+        }
+      }
+
+      // 这几行不能放到循环中，否则有多个敏感词位置重叠的时候就会显示多个 一键修复 按钮
+      const diagnosticsOnCurrentDocument = diagnosticCollection.get(document.uri);
+      if (diagnosticsOnCurrentDocument) {
+        const fixAll = new vscode.CodeAction('一键修复所有敏感词', vscode.CodeActionKind.QuickFix);
+        fixAll.edit = new vscode.WorkspaceEdit();
+
+        // 如果敏感词之间有重叠部分，直接替换就替换不了会报错，所以我们要解决一下重叠部分的问题
+        const diagnosticsSorted = Array.from(diagnosticsOnCurrentDocument).sort((a, b) => a.range.start.line === b.range.start.line ? a.range.start.character - b.range.start.character : a.range.start.line - b.range.start.line); // 先排序，便于处理重叠
+        const ranges: vscode.Range[] = [];
+        let rangeStartPos: vscode.Position = new vscode.Position(0, 0), rangeEndPos: vscode.Position = new vscode.Position(0, 0), isOverlapped = false; // 用 rangeStartPos 和 rangeEndPos 来记录敏感词的开始和结束位置
+        for (let i = 0; i < diagnosticsSorted.length; ++i) {
+          if (diagnosticsSorted[i].range.start.line === diagnosticsSorted[i + 1]?.range?.start?.line // 同一行
+            && i !== diagnosticsSorted.length - 1 // 不是最后一个敏感词，最后一个敏感词后面肯定不会有连着的了，直接push就好了
+            && diagnosticsSorted[i].range.end.character >= diagnosticsSorted[i + 1].range.start.character // 前一个结束的位置比后一个开始的位置大，存在重叠
+          ) {
+            if (!isOverlapped) {
+              // 之前没有重叠过的
+              rangeStartPos = diagnosticsSorted[i].range.start;
+              isOverlapped = true;
+            }
+            rangeEndPos = diagnosticsSorted[i + 1].range.end; // 更新结束位置
+          } else {
+            if (isOverlapped) {
+              // 之前重叠过，到这不重叠了
+              ranges.push(new vscode.Range(rangeStartPos, rangeEndPos));
+              isOverlapped = false;
+            } else {
+              ranges.push(diagnosticsSorted[i].range);
+            }
           }
         }
+
+        ranges.forEach(range => {
+          fixAll.edit!.replace(document.uri, range, '*'.repeat(range.end.character - range.start.character));
+        });
+
+        fixAll.diagnostics = [...diagnosticsOnCurrentDocument];
+        actions.push(fixAll);
       }
       return actions;
     }


### PR DESCRIPTION
在 #50 的提交中，我只是单纯的遍历所有诊断全部`replace`而已，然而这样的做法有点问题，如果敏感词之间重叠，`replace`就会产生冲突导致 一键替换 无法正常工作

这个pr改进了算法，能判定合并重复的敏感词区间，这样就能正常 一键替换

敏感词重叠的典型事例：`他妈的`