### PR TITLE
修改提示语中的 vscode 为 CEC-IDE

### DIFF
--- a/src/ModifyVsCodeUi.ts
+++ b/src/ModifyVsCodeUi.ts
@@ -89,7 +89,7 @@ async function injectionCSS(context: vscode.ExtensionContext) {
 					vscode.window.showErrorMessage('很遗憾，国产化失败！');
 					return;
 				}
-				vscode.window.showInformationMessage('已完成国产化，请重启vscode查看！');
+				vscode.window.showInformationMessage('已完成国产化，请重启 CEC-IDE 查看！');
 			});
 		};
 

--- a/src/sensitiveWords/CustomSensitiveWords.ts
+++ b/src/sensitiveWords/CustomSensitiveWords.ts
@@ -24,7 +24,7 @@ export function customSensitiveWords(context: vscode.ExtensionContext) {
           vscode.window.showInformationMessage("自定义敏感词失败。");
           return;
         }
-        vscode.window.showInformationMessage("自定义敏感词完成,请重启VSCode");
+        vscode.window.showInformationMessage("自定义敏感词完成, 请重启 CEC-IDE");
       });
     }
   });
@@ -35,7 +35,7 @@ export function customSensitiveWords(context: vscode.ExtensionContext) {
         vscode.window.showInformationMessage("重置敏感词失败。");
         return;
       }
-      vscode.window.showInformationMessage("重置敏感词完成,请重启VSCode");
+      vscode.window.showInformationMessage("重置敏感词完成, 请重启 CEC-IDE");
     });
   });
 


### PR DESCRIPTION
完成国产化后，我们使用的就是 CEC-IDE 而不是 vscode，所以应该把提示语中的 vscode 改为 CEC-IDE
（恢复那里的提示语还是 vscode 因为已经解除国产化了）