### PR TITLE
ts类型备案提示 / string, number, boolean 的备案提示

### DIFF
--- a/package.json
+++ b/package.json
@@ -131,10 +131,10 @@
     "@vscode/test-electron": "^2.3.4",
     "eslint": "^8.47.0",
     "glob": "^10.3.3",
-    "mocha": "^10.2.0",
-    "typescript": "^5.1.6"
+    "mocha": "^10.2.0"
   },
   "dependencies": {
-    "mint-filter": "^4.0.3"
+    "mint-filter": "^4.0.3",
+    "typescript": "^5.1.6"
   }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2,6 +2,7 @@ import * as vscode from 'vscode';
 import { sidebarInit } from './sidebar/sidebarInit';
 import { sensitiveWordDetectionInit } from './sensitiveWords/CheckForSensitiveWords';
 import { modifyVsCodeUI } from './ModifyVsCodeUi';
+import initializeTypeDetector from './typeDetector/main';
 
 export function activate(context: vscode.ExtensionContext) {
 	// 初始化侧边栏
@@ -10,6 +11,9 @@ export function activate(context: vscode.ExtensionContext) {
 	sensitiveWordDetectionInit(context);
 	// 修改VSCodeUI
 	modifyVsCodeUI(context);
+
+	// 初始化 Typescript 类型标记功能
+	initializeTypeDetector(context);
 }
 
 export function deactivate() { }

--- a/src/typeDetector/main.ts
+++ b/src/typeDetector/main.ts
@@ -1,0 +1,65 @@
+import * as vscode from 'vscode';
+import { ScriptTarget, createSourceFile, Statement, Node, SyntaxKind, VariableDeclaration } from 'typescript';
+
+const fileStates: {
+    [key: string]: boolean
+} = {};
+
+const diagnosticCollection: vscode.DiagnosticCollection = vscode.languages.createDiagnosticCollection('typescript');
+
+export default function initializeTypeDetector(context: vscode.ExtensionContext) {
+    vscode.window.onDidChangeActiveTextEditor(markType);
+    vscode.window.onDidChangeTextEditorOptions(markType);
+    markType();
+}
+
+function markType() {
+    const editor = vscode.window.activeTextEditor;
+    if (editor && editor.document.languageId === 'typescript') {
+        if (fileStates[editor.document.fileName]) {
+            return;
+        }
+        const content = editor.document.getText();
+        const sourcefile = createSourceFile(editor.document.fileName, content, ScriptTarget.ESNext);
+        const diagnostics: vscode.Diagnostic[] = [];
+        console.log(sourcefile.statements);
+        sourcefile.statements.forEach(statement => {
+            forEachNode(content, statement, diagnostics, editor.document);
+        });
+        diagnosticCollection.delete(editor.document.uri);
+        if (diagnostics) {
+            diagnosticCollection.set(editor.document.uri, diagnostics);
+        }
+    }
+}
+
+function forEachNode(source: string, node: Node, diagnostics: vscode.Diagnostic[], document: vscode.TextDocument) {
+    if (node.kind === SyntaxKind.VariableDeclaration) {
+        const declaration = node as VariableDeclaration;
+        const variableBasicType = declaration.type?.kind;
+        let typeName = '';
+        switch (variableBasicType) {
+            case SyntaxKind.StringKeyword: typeName = 'string'; break;
+            case SyntaxKind.NumberKeyword: typeName = 'number'; break;
+            case SyntaxKind.BooleanKeyword: typeName = 'boolean'; break;
+        }
+        if (typeName) {
+            // pos + n 是第 n 个字符的位置
+            generateDiagnostics(typeName, source.slice(declaration.name.pos + 1, declaration.name.end), [declaration.type!.pos + 1, declaration.type!.end], diagnostics, document);
+        }
+    }
+    node.forEachChild(node => forEachNode(source, node, diagnostics, document));
+}
+
+function generateDiagnostics(type: string, variableName: string, pos: [number, number], diagnostics: vscode.Diagnostic[], document: vscode.TextDocument) {
+    const range = new vscode.Range(
+        document.positionAt(pos[0]),
+        document.positionAt(pos[1])
+    );
+    const diagnostic = new vscode.Diagnostic(range, `未备案的类型: ${type}`, vscode.DiagnosticSeverity.Warning);
+    diagnostic.source = '类型备案提示';
+    diagnostic.relatedInformation = [
+        new vscode.DiagnosticRelatedInformation(new vscode.Location(document.uri, range), variableName)
+    ];
+    diagnostics.push(diagnostic);
+}


### PR DESCRIPTION
想睡觉不想熬夜了，时间匆忙，目前就写了这么点：

1. 只有语言类型为 TypeScript 的支持类型备案提示
2. 第一次打开、切换活动编辑器、更改编辑器选项（如语言）的时候才会激活程序进行备案提示，手动切换按钮没写
3. 提示的销毁也没写......
4. 仅在变量声明语句（如`const`，`var`，`let`）中**手动定义变量类型**（自动推导的不行，自动推导的`type`值是`undefined`，后面慢慢写），且变量类型为`string`，`number`，`boolean`时有提示（其他的比如说对象等类型是 TypeReference 要多写几步解析没时间写）

效果如图：
![image](https://github.com/qxchuckle/vsc-cec-ide/assets/94808542/9cae97ef-2109-4b31-8897-83d5942043df)
![image](https://github.com/qxchuckle/vsc-cec-ide/assets/94808542/0f22d16b-7958-4965-a0dd-2d1b900463ad)

先交一点，后面慢慢完善